### PR TITLE
📊 Runtime Metrics Server Implementation

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,3 +1,71 @@
 package main
 
-func main() {}
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type MemStorage struct {
+	gauges   map[string]float64
+	counters map[string]int64
+}
+
+func NewMemStorage() *MemStorage {
+	return &MemStorage{
+		gauges:   make(map[string]float64),
+		counters: make(map[string]int64),
+	}
+}
+
+func updateHandler(storage *MemStorage) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		parts := strings.Split(r.URL.Path, "/")
+
+		if len(parts) != 5 || parts[1] != "update" {
+			http.Error(w, "Invalid request path", http.StatusNotFound)
+			return
+		}
+
+		metricType := parts[2]
+		metricName := parts[3]
+		metricValue := parts[4]
+
+		switch metricType {
+		case "gauge":
+			value, err := strconv.ParseFloat(metricValue, 64)
+			if err != nil {
+				http.Error(w, "Invalid metric value", http.StatusBadRequest)
+				return
+			}
+			storage.gauges[metricName] = value
+
+		case "counter":
+			value, err := strconv.ParseInt(metricValue, 10, 64)
+			if err != nil {
+				http.Error(w, "Invalid metric value", http.StatusBadRequest)
+				return
+			}
+			storage.counters[metricName] += value
+
+		default:
+			http.Error(w, "Invalid metric type", http.StatusBadRequest)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func main() {
+	storage := NewMemStorage()
+
+	http.HandleFunc("/update/", updateHandler(storage))
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello, World!")
+	})
+
+	fmt.Println("Server running on http://localhost:8080")
+	http.ListenAndServe(":8080", nil)
+}


### PR DESCRIPTION
🎯 Description:
Implemented a server for collecting runtime metrics as part of the Metrics Collection & Alerting track.

✨ Features:
    Available at http://localhost:8080.
    Supports two metric types:
        gauge (float64)
        counter (int64)
    Receives metrics via HTTP POST.
    Endpoint:
        http://<SERVER_ADDRESS>/update/<METRIC_TYPE>/<METRIC_NAME>/<METRIC_VALUE>
    Uses MemStorage structure for data storage.
    Testing:
        Send HTTP POST requests to the mentioned endpoint and verify server responses.