### PR TITLE
Iter2

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,3 +1,93 @@
 package main
 
-func main() {}
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+const (
+	pollInterval   = 2 * time.Second
+	reportInterval = 10 * time.Second
+	serverEndpoint = "http://localhost:8080"
+)
+
+var pollCount int64
+
+func main() {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			metrics := gatherMetrics()
+			go reportMetrics(metrics)
+		}
+	}
+}
+
+func gatherMetrics() map[string]interface{} {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+
+	metrics := map[string]interface{}{
+		"Alloc":         float64(m.Alloc),
+		"BuckHashSys":   float64(m.BuckHashSys),
+		"Frees":         float64(m.Frees),
+		"GCCPUFraction": float64(m.GCCPUFraction),
+		"GCSys":         float64(m.GCSys),
+		"HeapAlloc":     float64(m.HeapAlloc),
+		"HeapIdle":      float64(m.HeapIdle),
+		"HeapInuse":     float64(m.HeapInuse),
+		"HeapObjects":   float64(m.HeapObjects),
+		"HeapReleased":  float64(m.HeapReleased),
+		"HeapSys":       float64(m.HeapSys),
+		"LastGC":        float64(m.LastGC),
+		"Lookups":       float64(m.Lookups),
+		"MCacheInuse":   float64(m.MCacheInuse),
+		"MCacheSys":     float64(m.MCacheSys),
+		"MSpanInuse":    float64(m.MSpanInuse),
+		"MSpanSys":      float64(m.MSpanSys),
+		"Mallocs":       float64(m.Mallocs),
+		"NextGC":        float64(m.NextGC),
+		"NumForcedGC":   float64(m.NumForcedGC),
+		"NumGC":         float64(m.NumGC),
+		"OtherSys":      float64(m.OtherSys),
+		"PauseTotalNs":  float64(m.PauseTotalNs),
+		"StackInuse":    float64(m.StackInuse),
+		"StackSys":      float64(m.StackSys),
+		"Sys":           float64(m.Sys),
+		"TotalAlloc":    float64(m.TotalAlloc),
+		"RandomValue":   rand.Float64(),
+		"PollCount":     pollCount,
+	}
+	pollCount++
+
+	return metrics
+}
+
+func reportMetrics(metrics map[string]interface{}) {
+	for name, value := range metrics {
+		var metricType, metricValue string
+
+		switch v := value.(type) {
+		case float64:
+			metricType = "gauge"
+			metricValue = fmt.Sprintf("%f", v)
+		case int64:
+			metricType = "counter"
+			metricValue = fmt.Sprintf("%d", v)
+		}
+
+		url := fmt.Sprintf("%s/update/%s/%s/%s", serverEndpoint, metricType, name, metricValue)
+		resp, err := http.Post(url, "text/plain", nil)
+		if err != nil {
+			fmt.Printf("Failed to send metric %s: %v\n", name, err)
+			continue
+		}
+		resp.Body.Close()
+	}
+}

--- a/cmd/agent/main_test.go
+++ b/cmd/agent/main_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGatherMetrics(t *testing.T) {
+	metrics := gatherMetrics()
+
+	if _, exists := metrics["Alloc"]; !exists {
+		t.Fatalf("Expected metric 'Alloc' to be present")
+	}
+
+	if val, exists := metrics["RandomValue"]; !exists || val.(float64) < 0 || val.(float64) > 1 {
+		t.Fatalf("Expected metric 'RandomValue' to be between 0 and 1")
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"os/signal"
 	"strconv"
 	"strings"
 )
@@ -54,6 +56,9 @@ func updateHandler(storage *MemStorage) http.HandlerFunc {
 			return
 		}
 
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		fmt.Fprintf(w, "Metric updated")
+
 		w.WriteHeader(http.StatusOK)
 	}
 }
@@ -65,6 +70,16 @@ func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "Hello, World!")
 	})
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+
+	go func() {
+		for sig := range c {
+			fmt.Printf("Caught signal %s: shutting down.\n", sig)
+			os.Exit(0)
+		}
+	}()
 
 	fmt.Println("Server running on http://localhost:8080")
 	http.ListenAndServe(":8080", nil)

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUpdateHandler(t *testing.T) {
+	storage := NewMemStorage()
+	handler := updateHandler(storage)
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	resp, err := http.Post(server.URL+"/update/gauge/testMetric/1.23", "text/plain", nil)
+	if err != nil {
+		t.Fatalf("Failed to send request: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected status OK; got %v", resp.Status)
+	}
+	if storage.gauges["testMetric"] != 1.23 {
+		t.Fatalf("Expected gauge value 1.23; got %v", storage.gauges["testMetric"])
+	}
+
+	resp, err = http.Post(server.URL+"/update/counter/testCounter/10", "text/plain", nil)
+	if err != nil {
+		t.Fatalf("Failed to send request: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected status OK; got %v", resp.Status)
+	}
+	if storage.counters["testCounter"] != 10 {
+		t.Fatalf("Expected counter value 10; got %v", storage.counters["testCounter"])
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/JShipov/metrics_collection_service
+
+go 1.21.0


### PR DESCRIPTION
### Metrics Agent Implementation

#### Overview:
Implemented an HTTP client agent for collecting runtime metrics and subsequently reporting them to a server using the HTTP protocol.

#### Details:
- Added metric types: `gauge` (float64) and `counter` (int64) using the `runtime` package.
- Introduced two additional metrics: `PollCount` (counter type) and `RandomValue` (gauge type).
- Configured default settings to update runtime metrics every 2 seconds (`pollInterval`) and report them to the server every 10 seconds (`reportInterval`).
- Metrics are sent via HTTP POST to the specified server endpoint.